### PR TITLE
SRC-6043 Remove unused 'rename' arguments

### DIFF
--- a/sr_utilities_common/launch/real_time_tf_republisher.launch
+++ b/sr_utilities_common/launch/real_time_tf_republisher.launch
@@ -3,8 +3,6 @@
   <arg name="remapped_tf_topic_name" default="tf_bag" />
   <arg name="tf_name_regexes" default="[]"/>
   <arg name="tcp_nodelay" default="true"/>
-  <arg name="rename_from" default="[]"/>
-  <arg name="rename_to" default="[]"/>
 
   <node unless="$(eval arg('rosbag_path') == '')" pkg="rosbag" type="play" name="rosbag_mocap_tf" args="$(arg rosbag_path) --topics /tf tf:=$(arg remapped_tf_topic_name) -l" output="screen" />
   <node pkg="sr_utilities_common" type="real_time_tf_republisher.py" name="real_time_tf_republisher" output="screen">


### PR DESCRIPTION
## Proposed changes

Revert https://github.com/shadow-robot/common_resources/pull/159 as `rename_from` and `rename_to` are not used.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
