### PR TITLE
SRC-6183 Various improvements for speech control

### DIFF
--- a/sr_speech_control/README.md
+++ b/sr_speech_control/README.md
@@ -1,16 +1,47 @@
 # sr_speech_control
 
-Package for controlling various systems using speech. Commands are being sent to a topic (default: `speech_control`) in a form of std_msgs String and can be intercepted by other nodes in order to execute actions.
+A node for controlling various systems using speech.
+Commands are being sent to a topic `sr_speech_control` in a form of std_msgs
+String and can be intercepted by other nodes in order to execute actions.
 
-# Usage
+## Usage
 
-Create a `SpeechControl` class object and run it using the `run()` method. Depending on the trigger word that you have chosed, commands (from the commands list specified in the class constructor) proceeded by that word will be executed, and all other words and phrases will be ignored. E.g., if your trigger word is `Shadow` and you say `execute grasp`, no messages will be send to the topic. On the other hand, if you say `shadow grasp`, a `grasp` message will be sent.
-
-Example class implementation:
-
-```python
-    trigger_word = "shadow"
-    command_words = ["grasp", "release", "disable", "enable"]
-    sc = SpeechControl(trigger_word, command_words)
-    sc.run()
+To start the node run:
 ```
+rosrun sr_speech_control speech_control.py
+```
+
+The node will permanenly listen to the microphone input, will use Google speech
+recognition to translate audio to text, check if text starts with a trigger
+word `shadow` and if so will publish text after the trigger word to topic
+`sr_speech_control`.
+
+## Known problems
+
+Testing revealed that microphone devices available within Docker container are
+significantly worse than on the host machine. That can be easily demonstrated
+by testing Google Chrome browser speech recognition on the host and inside
+Docker container. Known workaround for that is to use pulseaudio server on host
+machine for sound capture. For that install `paprefs` program on the host:
+```
+sudo apt-get install paprefs
+```
+and run it. In "Network Server" tab, and check the "Enable network access to
+local sound devices" checkbox and other two sub-checkboxes in order not to
+require authentications. You might need to reboot host machine for this setting
+to be used.
+Run `pax11publish` utility program to find out pulseaudio server port (most
+likely 4713).
+On the container run:
+```
+export "PULSE_SERVER=tcp:<host IP address>:<host pulseaudio port>"
+```
+For example if your host IP address is `192.168.1.2`, then run:
+```
+export "PULSE_SERVER=tcp:192.168.1.2:4713"
+```
+`sr_speech_control` node is already configured to use microphone containing
+`pulse` in its name so steps above should be sufficiend to use host microphone.
+
+Alternatively it is possible to map unix sockets instead of tcp but it requires
+adding new parameters when launching Docker container.

--- a/sr_speech_control/README.md
+++ b/sr_speech_control/README.md
@@ -40,8 +40,10 @@ For example if your host IP address is `192.168.1.2`, then run:
 ```
 export "PULSE_SERVER=tcp:192.168.1.2:4713"
 ```
-`sr_speech_control` node is already configured to use microphone containing
-`pulse` in its name so steps above should be sufficiend to use host microphone.
-
 Alternatively it is possible to map unix sockets instead of tcp but it requires
 adding new parameters when launching Docker container.
+
+To use node with pulseaudio microphone specify `prefer_microphone` parameter:
+```
+rosrun sr_speech_control speech_control.py _prefer_microphone:=pulse
+```

--- a/sr_speech_control/src/sr_speech_control/speech_control.py
+++ b/sr_speech_control/src/sr_speech_control/speech_control.py
@@ -15,9 +15,7 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import rospy
-import time
 import speech_recognition as sr
-from difflib import get_close_matches
 from std_msgs.msg import String
 
 

--- a/sr_speech_control/src/sr_speech_control/speech_control.py
+++ b/sr_speech_control/src/sr_speech_control/speech_control.py
@@ -52,9 +52,10 @@ class SpeechControl(object):
             rospy.logwarn("Could not request results from Google Speech Recognition service: {}".format(e))
             return
 
-        result = [self._filter_word(str(x).lower(), self.command_words) for x in result.split(' ')]
-        if result[0] == self.trigger_word:
-            self.command_publisher.publish(' '.join(result[1:]))
+        result = [str(x).lower() for x in result.split(' ')]
+        if len(result) > 1:
+            if self._filter_word(result[0], [self.trigger_word]) == self.trigger_word:
+                self.command_publisher.publish(' '.join([self._filter_word(x, self.command_words) for x in result[1:]]))
 
     def _filter_word(self, word, dictionary, offset=0.5):
         result = get_close_matches(word, dictionary, 1, offset)

--- a/sr_speech_control/src/sr_speech_control/speech_control.py
+++ b/sr_speech_control/src/sr_speech_control/speech_control.py
@@ -35,7 +35,6 @@ class SpeechControl(object):
     def _recognizer_callback(self, recognizer, audio):
         try:
             result = recognizer.recognize_google(audio)
-            rospy.loginfo("Recognition result: {}".format(result))
         except sr.UnknownValueError:
             return
         except sr.RequestError as e:

--- a/sr_speech_control/src/sr_speech_control/speech_control.py
+++ b/sr_speech_control/src/sr_speech_control/speech_control.py
@@ -63,8 +63,8 @@ class SpeechControl(object):
         return result[0]
 
     def run(self):
-        rospy.loginfo("Started speech control. Trigger word: {}, command words: {}"
-            .format(self.trigger_word, self.command_words))
+        rospy.loginfo("Started speech control. Trigger word: {}, command words: {}".format(
+            self.trigger_word, self.command_words))
         rospy.spin()
         self._stop_listening(wait_for_stop=False)
 

--- a/sr_speech_control/src/sr_speech_control/speech_control.py
+++ b/sr_speech_control/src/sr_speech_control/speech_control.py
@@ -48,8 +48,7 @@ class SpeechControl(object):
 
     def run(self):
         rospy.loginfo("Started speech control. Trigger word: {}".format(self.trigger_word))
-        while not rospy.is_shutdown():
-            rospy.sleep(1)
+        rospy.spin()
         self._stop_listening(wait_for_stop=False)
 
 

--- a/sr_speech_control/src/sr_speech_control/speech_control.py
+++ b/sr_speech_control/src/sr_speech_control/speech_control.py
@@ -62,15 +62,11 @@ class SpeechControl(object):
             return word
         return result[0]
 
-    def run(self):
-        rospy.loginfo("Started speech control. Trigger word: {}, command words: {}".format(
-            self.trigger_word, self.command_words))
-        rospy.spin()
-        self._stop_listening(wait_for_stop=False)
-
-
 if __name__ == "__main__":
     rospy.init_node('sr_speech_control', anonymous=True)
 
     sc = SpeechControl()
-    sc.run()
+    rospy.loginfo("Started speech control. Trigger word: {}, command words: {}".format(
+        sc.trigger_word, sc.command_words))
+    rospy.spin()
+    sc._stop_listening(wait_for_stop=False)

--- a/sr_speech_control/src/sr_speech_control/speech_control.py
+++ b/sr_speech_control/src/sr_speech_control/speech_control.py
@@ -15,6 +15,7 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import rospy
+import argparse
 import speech_recognition as sr
 from std_msgs.msg import String
 
@@ -52,8 +53,11 @@ class SpeechControl(object):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Publish control commands using voice recognition.')
+    parser.add_argument('--trigger-word', default='shadow')
+    args = parser.parse_args(rospy.myargv()[1:])
+
     rospy.init_node('sr_speech_control', anonymous=True)
 
-    trigger_word = "shadow"
-    sc = SpeechControl(trigger_word)
+    sc = SpeechControl(args.trigger_word)
     sc.run()

--- a/sr_speech_control/src/sr_speech_control/speech_control.py
+++ b/sr_speech_control/src/sr_speech_control/speech_control.py
@@ -26,6 +26,7 @@ class SpeechControl(object):
             if "pulse" in microphone_name:
                 self.microphone = sr.Microphone(device_index=i)
                 rospy.loginfo("Using microphone: {}".format(microphone_name))
+                break
         self.trigger_word = trigger_word
         self.recognizer = sr.Recognizer()
         self.command_publisher = rospy.Publisher(command_topic, String, queue_size=1)

--- a/sr_speech_control/src/sr_speech_control/speech_control.py
+++ b/sr_speech_control/src/sr_speech_control/speech_control.py
@@ -21,12 +21,12 @@ from std_msgs.msg import String
 
 
 class SpeechControl(object):
-    def __init__(self, trigger_word, command_topic='sr_speech_control'):
+    def __init__(self, prefer_microphone, trigger_word, command_topic='sr_speech_control'):
         self.microphone = sr.Microphone()
         for i, microphone_name in enumerate(sr.Microphone.list_microphone_names()):
-            if "pulse" in microphone_name:
+            if prefer_microphone in microphone_name:
                 self.microphone = sr.Microphone(device_index=i)
-                rospy.loginfo("Using microphone: {}".format(microphone_name))
+                rospy.loginfo("Using preferred microphone: {}".format(microphone_name))
                 break
         self.trigger_word = trigger_word
         self.recognizer = sr.Recognizer()
@@ -55,9 +55,10 @@ class SpeechControl(object):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Publish control commands using voice recognition.')
     parser.add_argument('--trigger-word', default='shadow')
+    parser.add_argument('--prefer-microphone', default='pulse')
     args = parser.parse_args(rospy.myargv()[1:])
 
     rospy.init_node('sr_speech_control', anonymous=True)
 
-    sc = SpeechControl(args.trigger_word)
+    sc = SpeechControl(args.prefer_microphone, args.trigger_word)
     sc.run()

--- a/sr_speech_control/src/sr_speech_control/speech_control.py
+++ b/sr_speech_control/src/sr_speech_control/speech_control.py
@@ -22,59 +22,41 @@ from std_msgs.msg import String
 
 
 class SpeechControl(object):
-    def __init__(self, trigger_word, command_words, command_topic='speech_control',
-                 non_speaking_duration=0.1, pause_threshold=0.2):
-        self.trigger_word = trigger_word
-        self.command_words = command_words
-        self.recognizer = sr.Recognizer()
+    def __init__(self, trigger_word, command_topic='sr_speech_control'):
         self.microphone = sr.Microphone()
+        for i, microphone_name in enumerate(sr.Microphone.list_microphone_names()):
+            if "pulse" in microphone_name:
+                self.microphone = sr.Microphone(device_index=i)
+                rospy.loginfo("Using microphone: {}".format(microphone_name))
+        self.trigger_word = trigger_word
+        self.recognizer = sr.Recognizer()
         self.command_publisher = rospy.Publisher(command_topic, String, queue_size=1)
-        self.command_to_be_executed = None
-
-        self._init_recognizer(non_speaking_duration, pause_threshold)
         self._stop_listening = self.recognizer.listen_in_background(self.microphone, self._recognizer_callback)
-
-    def _init_recognizer(self, non_speaking_duration, pause_threshold):
-        with self.microphone as source:
-            self.recognizer.adjust_for_ambient_noise(source)
-        self.recognizer.non_speaking_duration = non_speaking_duration
-        self.recognizer.pause_threshold = pause_threshold
 
     def _recognizer_callback(self, recognizer, audio):
         try:
             result = recognizer.recognize_google(audio)
+            rospy.loginfo("Recognition result: {}".format(result))
         except sr.UnknownValueError:
             return
         except sr.RequestError as e:
             rospy.logwarn("Could not request results from Google Speech Recognition service: {}".format(e))
             return
 
-        result = [str(x).lower() for x in result.split(' ')]
-        if self._filter_word(result[0], self.trigger_word) == self.trigger_word:
-            command = self._filter_word(result[1], self.command_words)
-            if command in self.command_words:
-                self.command_to_be_executed = command
-
-    def _filter_word(self, word, dictionary, offset=0.5):
-        result = get_close_matches(word, dictionary, 1, offset)
-        if not result:
-            return word
-        return result[0]
+        result = result.lower()
+        if result.startswith(self.trigger_word) and len(result) > len(self.trigger_word) + 1:
+            self.command_publisher.publish(result[len(self.trigger_word) + 1:])
 
     def run(self):
         rospy.loginfo("Started speech control. Trigger word: {}".format(self.trigger_word))
         while not rospy.is_shutdown():
-                if self.command_to_be_executed:
-                    rospy.loginfo("Executing: {}.".format(self.command_to_be_executed))
-                    self.command_publisher.publish(self.command_to_be_executed)
-                    self.command_to_be_executed = None
+            rospy.sleep(1)
         self._stop_listening(wait_for_stop=False)
 
 
 if __name__ == "__main__":
-    rospy.init_node('example_speech_control', anonymous=True)
+    rospy.init_node('sr_speech_control', anonymous=True)
 
     trigger_word = "shadow"
-    command_words = ["grasp", "release", "disable", "enable"]
-    sc = SpeechControl(trigger_word, command_words)
+    sc = SpeechControl(trigger_word)
     sc.run()


### PR DESCRIPTION
## Proposed changes

* Assume that `sr_speech_control` will be used as voice control node rather than just base class for other voice related nodes.
* Replace busy wait in main loop with spin and publish inside callback function to prevent always using 100% CPU.
* Add `sr_` prefix to topic.
* Change node prefix from `example_` to `sr_`.
* Add parameters for `topic`, `prefer_microphone`, `trigger_word`, `command_words`, `non_speaking_duration` and `pause_threshold`.
* Document possible workaround for poor recognition performance using pulseaudio server on host machine.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
