### PR TITLE
Limiting sim speeds to 1.0, now that CPUs are fast enough.

### DIFF
--- a/sr_description_common/worlds/alpha_glovebox.world
+++ b/sr_description_common/worlds/alpha_glovebox.world
@@ -29,7 +29,7 @@
           <contact_surface_layer>0.00000</contact_surface_layer>
         </constraints>
       </ode>
-      <real_time_update_rate>1000.0</real_time_update_rate>
+      <real_time_factor>1.0</real_time_factor>
       <max_step_size>0.001000</max_step_size>
     </physics>
 

--- a/sr_description_common/worlds/demo_space_large_bimanual.world
+++ b/sr_description_common/worlds/demo_space_large_bimanual.world
@@ -79,7 +79,7 @@
           <contact_surface_layer>0.00000</contact_surface_layer>
         </constraints>
       </ode>
-      <real_time_update_rate>0.000000</real_time_update_rate>
+      <real_time_factor>1.0</real_time_factor>
       <max_step_size>0.001000</max_step_size>
     </physics>
     <scene>

--- a/sr_description_common/worlds/demo_space_large_bimanual_server_rack.world
+++ b/sr_description_common/worlds/demo_space_large_bimanual_server_rack.world
@@ -81,7 +81,7 @@
           <contact_surface_layer>0.00000</contact_surface_layer>
         </constraints>
       </ode>
-      <real_time_update_rate>0.000000</real_time_update_rate>
+      <real_time_factor>1.0</real_time_factor>
       <max_step_size>0.001000</max_step_size>
     </physics>
     <scene>

--- a/sr_description_common/worlds/demo_space_large_unimanual.world
+++ b/sr_description_common/worlds/demo_space_large_unimanual.world
@@ -67,7 +67,7 @@
           <contact_surface_layer>0.00000</contact_surface_layer>
         </constraints>
       </ode>
-      <real_time_update_rate>1000.0</real_time_update_rate>
+      <real_time_factor>1.0</real_time_factor>
       <max_step_size>0.001000</max_step_size>
     </physics>
     <scene>

--- a/sr_description_common/worlds/demo_space_small.world
+++ b/sr_description_common/worlds/demo_space_small.world
@@ -61,7 +61,7 @@
           <contact_surface_layer>0.00000</contact_surface_layer>
         </constraints>
       </ode>
-      <real_time_update_rate>1000.0</real_time_update_rate>
+      <real_time_factor>1.0</real_time_factor>
       <max_step_size>0.001000</max_step_size>
     </physics>
     <scene>

--- a/sr_description_common/worlds/ms_garage.world
+++ b/sr_description_common/worlds/ms_garage.world
@@ -83,7 +83,7 @@
           <contact_surface_layer>0.00000</contact_surface_layer>
         </constraints>
       </ode>
-      <real_time_update_rate>0.000000</real_time_update_rate>
+      <real_time_factor>1.0</real_time_factor>
       <max_step_size>0.001000</max_step_size>
     </physics>
     <scene>

--- a/sr_description_common/worlds/ms_lab.world
+++ b/sr_description_common/worlds/ms_lab.world
@@ -59,7 +59,7 @@
           <contact_surface_layer>0.00000</contact_surface_layer>
         </constraints>
       </ode>
-      <real_time_update_rate>0.000000</real_time_update_rate>
+      <real_time_factor>1.0</real_time_factor>
       <max_step_size>0.001000</max_step_size>
     </physics>
     <scene>

--- a/sr_description_common/worlds/shadowhand.world
+++ b/sr_description_common/worlds/shadowhand.world
@@ -33,7 +33,7 @@
           <contact_surface_layer>0.00000</contact_surface_layer>
         </constraints>
       </ode>
-      <real_time_update_rate>1000.0</real_time_update_rate>
+      <real_time_factor>1.0</real_time_factor>
       <max_step_size>0.001000</max_step_size>
     </physics>
     <gui fullscreen='0'>

--- a/sr_description_common/worlds/shadowhands_and_arms.world
+++ b/sr_description_common/worlds/shadowhands_and_arms.world
@@ -33,7 +33,7 @@
           <contact_surface_layer>0.00000</contact_surface_layer>
         </constraints>
       </ode>
-      <real_time_update_rate>1000.0</real_time_update_rate>
+      <real_time_factor>1.0</real_time_factor>
       <max_step_size>0.001000</max_step_size>
     </physics>
     <gui fullscreen='0'>


### PR DESCRIPTION
## Proposed changes

CPUs are now fast enough that running simulated teleop with no hand (box) now results in 7+ times real speed, which really confuses the rest of the system. This PR modifies the .world files to limit simulation time factor to 1.0. Slower machines will still just do their best to hit 1.0.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] ~~Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).~~
- [x] ~~Tested on real hardware (if the changed or added code is used with the real hardware).~~
- [x] ~~Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)~~
