### PR TITLE
Move conditional delayed rostool to src and add launch prefix for launching nodes

### DIFF
--- a/sr_utilities_common/CMakeLists.txt
+++ b/sr_utilities_common/CMakeLists.txt
@@ -169,6 +169,7 @@ target_link_libraries(relay ${catkin_LIBRARIES})
 ## in contrast to setup.py, you can choose the destination
 install(PROGRAMS
         src/sr_utilities_common/heartbeat_publisher.py
+        src/sr_utilities_common/conditional_delayed_rostool.py
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/sr_utilities_common/setup.py
+++ b/sr_utilities_common/setup.py
@@ -5,7 +5,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 d = generate_distutils_setup(
     packages=['sr_utilities_common'],
     scripts=[],
-    package_dir={'': 'scripts', '': 'src'}
+    package_dir={'': 'src'}
 )
 
 setup(**d)

--- a/sr_utilities_common/src/sr_utilities_common/conditional_delayed_rostool.py
+++ b/sr_utilities_common/src/sr_utilities_common/conditional_delayed_rostool.py
@@ -90,6 +90,7 @@ if __name__ == "__main__":
     package_name = rospy.get_param("~package_name")
     executable_name = rospy.get_param("~executable_name")
     arguments_list = rospy.get_param("~launch_args_list", "")
+    node_launch_prefix = rospy.get_param("~launch_prefix", "")
     timeout = rospy.get_param("~timeout", 0)
 
     if rospy.has_param('~topics_list'):
@@ -108,7 +109,7 @@ if __name__ == "__main__":
         if executable_name.endswith('.launch'):
             os.system("roslaunch {} {} {}".format(package_name, executable_name, arguments_list))
         else:
-            os.system("rosrun {} {} {}".format(package_name, executable_name, arguments_list))
+            os.system("{} rosrun {} {} {}".format(node_launch_prefix, package_name, executable_name, arguments_list))
     else:
         rospy.logfatal("{}: Could not launch {} {}, make sure all required conditions are met".format(rospy.get_name(),
                                                                                                       package_name,


### PR DESCRIPTION
## Proposed changes

Move conditional delayed rostool to src since setup.py does not allow multiple package_dir for same package, and add launch prefix for launching nodes.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
