### PR TITLE
SRC-6731 Replace PyDub library with a direct call to ffmpeg

### DIFF
--- a/sr_speech_control/README.md
+++ b/sr_speech_control/README.md
@@ -4,14 +4,6 @@ A node for controlling various systems using speech.
 Commands are being sent to a chosen topic in a form of std_msgs
 String and can be intercepted by other nodes in order to execute actions.
 
-## Requirements
-
-In order to use the voice feedback it is obligatory to install the related audio libary. For this purpose we are using forked [PyDub](https://github.com/jiaaro/pydub/tree/master/pydub) with custom changes (output device selection) which can be installed by running:
-
-```
-pip install git+https://github.com/shadow-robot/pydub@output_selection
-```
-
 ## Usage
 
 To start the node run:

--- a/sr_speech_control/src/sr_speech_control/speech_control.py
+++ b/sr_speech_control/src/sr_speech_control/speech_control.py
@@ -105,7 +105,7 @@ class SpeechControl(object):
                               stdin=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
             # Piping mp3 to ffmepg standard input must be in a separate thread because pipe
             # buffers are relatively small and process will block before any output is received
-            thread = Thread(target = self.write_mp3, args = (tts, proc, ))
+            thread = Thread(target=self.write_mp3, args=(tts, proc, ))
             thread.start()
             # Read wav from ffmpeg standard output
             wf = wave.open(proc.stdout, 'rb')

--- a/sr_speech_control/src/sr_speech_control/speech_control.py
+++ b/sr_speech_control/src/sr_speech_control/speech_control.py
@@ -28,14 +28,9 @@ from builtins import input
 from gtts import gTTS
 from io import BytesIO
 import pyaudio
-
-try:
-    from pydub import AudioSegment
-    from pydub.playback import play
-except (ImportError, ModuleNotFoundError) as e:
-    rospy.logerr("Custom PyDub is not installed. No voice feedback.")
-    rospy.logerr("Install by running pip install git+https://github.com/shadow-robot/pydub@output_selection")
-    raise
+import subprocess
+from threading import Thread
+import wave
 
 
 class SpeechControl(object):
@@ -89,22 +84,41 @@ class SpeechControl(object):
         if self.speaker != '':
             self.text_to_speech(message.data, self.speaker)
 
+    def write_mp3(self, tts, proc):
+        tts.write_to_fp(proc.stdin)
+        proc.stdin.close()
+
     def text_to_speech(self, text, device_name):
-        tts = gTTS(text=text, lang='en', slow=False)
-        fp = BytesIO()
-        tts.write_to_fp(fp)
-        fp.seek(0)
-        audio = AudioSegment.from_file(fp, format="mp3")
-
         p = pyaudio.PyAudio()
-        output_device_index = None
-        output_device_rate = None
-
+        device_index = None
+        sample_rate = None
         for index in range(0, p.get_device_count()):
             device_info = p.get_device_info_by_index(index)
             if device_name == device_info['name']:
-                audio = audio.set_frame_rate(int(device_info['defaultSampleRate']))
-                play(audio, index)
+                device_index = index
+                sample_rate = device_info['defaultSampleRate']
+                break
+        tts = gTTS(text=text, lang='en', slow=False)
+        # Use ffmpeg top convert mp3 to wav
+        with subprocess.Popen(['ffmpeg', '-loglevel', 'quiet', '-i', 'pipe:',
+                               '-ar', str(sample_rate), '-ac', '1', '-f', 'wav', 'pipe:'],
+                              stdin=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
+            # Piping mp3 to ffmepg standard input must be in a separate thread because pipe
+            # buffers are relatively small and process will block before any output is received
+            thread = Thread(target = self.write_mp3, args = (tts, proc, ))
+            thread.start()
+            # Read wav from ffmpeg standard output
+            wf = wave.open(proc.stdout, 'rb')
+            stream = p.open(format=p.get_format_from_width(wf.getsampwidth()),
+                            channels=wf.getnchannels(),
+                            rate=wf.getframerate(),
+                            output_device_index=device_index,
+                            output=True)
+            stream.write(wf.readframes(wf.getnframes()))
+            stream.stop_stream()
+            stream.close()
+            p.terminate()
+            thread.join()
 
     def parse_similar_words_dict(self, path_name):
         with open(path_name, 'r') as stream:


### PR DESCRIPTION
## Proposed changes

We were using out PyDub fork because original library would not allow to select output device. Since PyDub library uses `ffmpeg` for `mp3` to `wav` conversion we can use it directly ourselves and eliminate need to maintain yet another fork.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [x] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added automated tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
