### PR TITLE
Fix error with decoding git commands release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: public.ecr.aws/shadowrobot/build-tools:focal-noetic
         environment:
-          toolset_branch: python3
+          toolset_branch: master
           server_type: circle
           ros_release_name: noetic
           ubuntu_version_name: focal

--- a/sr_logging_common/logging/ws_diff.py
+++ b/sr_logging_common/logging/ws_diff.py
@@ -30,10 +30,9 @@ def recursive_diff(path):
     output = ""
     if os.path.isdir("./.git"):
         output = "\n\n------------------" + path + "------------------\n\n"
-        output += subprocess.check_output(['git', 'show']).decode("utf-8")
-        output += subprocess.check_output(['git', 'status']).decode("utf-8")
-        output += subprocess.check_output(['git', 'diff']).decode("utf-8")
-
+        output += subprocess.check_output(['git', 'show'], encoding='utf-8', errors='replace')
+        output += subprocess.check_output(['git', 'status'], encoding='utf-8', errors='replace')
+        output += subprocess.check_output(['git', 'diff'], encoding='utf-8', errors='replace')
     for subdir in filter(os.path.isdir, os.listdir(".")):
         output += recursive_diff(subdir)
 


### PR DESCRIPTION
## Proposed changes

Decoding git commands with utf-8 from bytes with the subprocess.check_output command was causing failure. THis might be due to a change in git bytes encoding. Using replace errors will take care of replacing invalid characters during the conversion.
This is the cherry-picked git commit from same PR https://github.com/shadow-robot/common_resources/pull/220 opened for noetic-devel

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [ ] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
