### PR TITLE
B#sp 291 fix bag rotate prefix

### DIFF
--- a/sr_logging_common/launch/sr_rosbag_log.launch
+++ b/sr_logging_common/launch/sr_rosbag_log.launch
@@ -37,6 +37,7 @@
   <node if="$(arg clear_old_sessions)" pkg="sr_logging_common" type="bag_rotate.py" name="$(anon bag_rotate)">
     <param name="bag_files_num" value="$(arg log_max_splits)"/>
     <param name="bag_files_path" value="$(arg log_directory)"/>
+    <param name="bag_files_prefix" value="$(arg log_bag_prefix)"/>
   </node>
 
   <node if="$(arg save_params)" pkg="sr_logging_common" type="record_params.py" name="$(anon param_dump)">

--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -22,8 +22,10 @@ import time
 import rospy
 import subprocess
 
+
 def starts_and_ends_with(file_name, prefix, suffix):
     return file_name.startswith(prefix) and file_name.endswith(suffix)
+
 
 def remover(desired_bag_number, path, file_name_prefix):
     while not rospy.is_shutdown():
@@ -39,7 +41,8 @@ def remover(desired_bag_number, path, file_name_prefix):
 
 
 def gather_and_fix_all_active_rosbag_files(path, file_name_prefix):
-    active_rosbags = [join(path, bagfile) for bagfile in listdir(path) if starts_and_ends_with(bagfile, file_name_prefix, '.bag.active')]  
+    active_rosbags = [join(path, bagfile) for bagfile in listdir(path)
+                      if starts_and_ends_with(bagfile, file_name_prefix, '.bag.active')]
     for bag_file in active_rosbags:
         file_name = bag_file.split(".active")[0]
         process = subprocess.run(["rosbag", "reindex", bag_file], capture_output=True, text=True)


### PR DESCRIPTION
## Proposed changes

[Bug SP-291](https://shadowrobot.atlassian.net/browse/SP-291)
The problem was occuring due to unchecked concurrency. bag_rotate.py was being called in 2 distinct launch files (srhand.launch and sr_hardware_control_loop.launch).

Each time, all bag.active files are listed, re-indexed and fixed. Both executions see the same files and try to operate them.

Since bag_rotate.py is launched from within sr_rosbag_log.launch, which makes use of the argument “bag_files_prefix“ in order to record and handle log files specific to each components, it is simply necessary that bag_rotate.py also uses this prefix to operate each subset of files at each time.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [X] Manually tested on hardware (if hardware specific or related).

## Documentation

- [X] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
