### PR TITLE
Fixing rosbag rotate 

### DIFF
--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -32,6 +32,7 @@ def rosbag_starts_and_ends_with(bag_file_name, prefix, suffix):
     bag_prefix = bag_file_name[0:match.span()[0]-1]
     return bag_prefix == prefix
 
+
 def remover(desired_bag_number, path, file_name_prefix):
     while not rospy.is_shutdown():
         bag_files = [bagfile for bagfile in listdir(path)

--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -25,13 +25,12 @@ import subprocess
 
 
 def rosbag_starts_and_ends_with(bag_file_name, prefix, suffix):
-    if bag_file_name.endswith(suffix):
-        match = search(r'\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}', bag_file_name)
-        bag_prefix = bag_file_name[0:match.span()[0]-1]
-        return bag_prefix == prefix
+    if not bag_file_name.endswith(suffix):
+        return False
 
-    return False
-
+    match = search(r'\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}', bag_file_name)
+    bag_prefix = bag_file_name[0:match.span()[0]-1]
+    return bag_prefix == prefix
 
 def remover(desired_bag_number, path, file_name_prefix):
     while not rospy.is_shutdown():

--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -35,7 +35,8 @@ def rosbag_starts_and_ends_with(bag_file_name, prefix, suffix):
 
 def remover(desired_bag_number, path, file_name_prefix):
     while not rospy.is_shutdown():
-        bag_files = [bagfile for bagfile in listdir(path) if rosbag_starts_and_ends_with(bagfile, file_name_prefix, '.bag')]
+        bag_files = [bagfile for bagfile in listdir(path)
+                     if rosbag_starts_and_ends_with(bagfile, file_name_prefix, '.bag')]
 
         sorted_bag_files = sorted(bag_files, key=lambda x: getctime(join(path, x)))
 

--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -25,9 +25,12 @@ import subprocess
 
 
 def rosbag_starts_and_ends_with(bag_file_name, prefix, suffix):
-    match = search(r'\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}', bag_file_name)
-    bag_prefix = rosbag_name[0:match.span()[0]-1]
-    return bag_prefix == prefix and bag_file_name.endswith(suffix)
+    if bag_file_name.endswith(suffix):
+        match = search(r'\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}', bag_file_name)
+        bag_prefix = bag_file_name[0:match.span()[0]-1]
+        return bag_prefix == prefix
+
+    return False
 
 
 def remover(desired_bag_number, path, file_name_prefix):


### PR DESCRIPTION
## Proposed changes

Rosbag rotate was failiing with hand and glove because one of the instances of the node was trying to remove one file that had already been removed by another instance. The reason this was happening was because in hand and glove there are two different prefixes sr_hand and sr_hand_glove and one of them is contained within the other, and so one of the nodes was trying to remove both of them.

I added a more specific search of the prefix (assuming that the prefix is always what is in the left of the date of the rosbag), but this also could be fixed by choosing prefixes that are not contained within other prefixes.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
