### PR TITLE
Fixing rosbag rotate

### DIFF
--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -17,19 +17,26 @@
 from __future__ import absolute_import
 from os import listdir, remove
 from os.path import getctime, join, exists
+from re import search
 import sys
 import time
 import rospy
 import subprocess
 
 
-def starts_and_ends_with(file_name, prefix, suffix):
-    return file_name.startswith(prefix) and file_name.endswith(suffix)
+def rosbag_starts_and_ends_with(bag_file_name, prefix, suffix):
+    if not bag_file_name.endswith(suffix):
+        return False
+
+    match = search(r'\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}', bag_file_name)
+    bag_prefix = bag_file_name[0:match.span()[0]-1]
+    return bag_prefix == prefix
 
 
 def remover(desired_bag_number, path, file_name_prefix):
     while not rospy.is_shutdown():
-        bag_files = [bagfile for bagfile in listdir(path) if starts_and_ends_with(bagfile, file_name_prefix, '.bag')]
+        bag_files = [bagfile for bagfile in listdir(path)
+                     if rosbag_starts_and_ends_with(bagfile, file_name_prefix, '.bag')]
 
         sorted_bag_files = sorted(bag_files, key=lambda x: getctime(join(path, x)))
 
@@ -42,7 +49,7 @@ def remover(desired_bag_number, path, file_name_prefix):
 
 def gather_and_fix_all_active_rosbag_files(path, file_name_prefix):
     active_rosbags = [join(path, bagfile) for bagfile in listdir(path)
-                      if starts_and_ends_with(bagfile, file_name_prefix, '.bag.active')]
+                      if rosbag_starts_and_ends_with(bagfile, file_name_prefix, '.bag.active')]
     for bag_file in active_rosbags:
         file_name = bag_file.split(".active")[0]
         process = subprocess.run(["rosbag", "reindex", bag_file], capture_output=True, text=True)


### PR DESCRIPTION
## Proposed changes

Rosbag rotate was failiing with hand and glove because one of the instances of the node was trying to remove one file that had already been removed by another instance. The reason this was happening was because in hand and glove there are two different prefixes sr_hand and sr_hand_glove and one of them is contained within the other, and so one of the nodes was trying to remove both of them.

I added a more specific search of the prefix (assuming that the prefix is always what is in the left of the date of the rosbag), but this also could be fixed by choosing prefixes that are not contained within other prefixes.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
