### PR TITLE
Removing reindexing from rosbag rotate

### DIFF
--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -14,9 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from os import listdir, remove, rename
-from os.path import exists
-import subprocess
+from os import listdir, remove
 import rospy
 
 

--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -28,11 +28,11 @@ class SrBagRotate:
         self.run()
 
     def remove_old_bags(self):
-        bags_to_remove = self.get_file_paths_by_key(".bag")
-        bags_to_remove.sort()
+        existing_bags = self.get_file_paths_by_key(".bag")
+        existing_bags.sort()
 
-        for i, bag in enumerate(bags_to_remove):
-            if i < len(bags_to_remove)-self._desired_bag_number - 1:
+        for i, bag in enumerate(existing_bags):
+            if i < len(existing_bags)-self._desired_bag_number - 1:
                 remove(bag)
 
     def get_file_paths_by_key(self, key):

--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2019, 2022 Shadow Robot Company Ltd.
+# Copyright 2019, 2022-2023 Shadow Robot Company Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the Free

--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -41,6 +41,7 @@ class SrBagRotate:
 
     def remove_old_bags(self):
         bags_to_remove = self.get_suffixed_bags(".bag")
+        bags_to_remove.extend(self.get_suffixed_bags(".bag.active"))
         bags_to_remove.extend(self.get_suffixed_bags(".bag.orig.active"))
         bags_to_remove.sort()
 
@@ -60,9 +61,6 @@ class SrBagRotate:
 
     def run(self):
         while not rospy.is_shutdown():
-            active_bags = self.get_suffixed_bags(".bag.active")
-            for bag in active_bags:
-                reindex_bag(bag)
             self.remove_old_bags()
             rospy.sleep(1)
 

--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -15,6 +15,7 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from os import listdir, remove
+from os.path import join
 import rospy
 
 
@@ -36,7 +37,7 @@ class SrBagRotate:
 
     def get_file_paths_by_key(self, key):
         all_files = listdir(self._path)
-        matching_files = [f"{self._path}/{s_file}" for s_file in all_files if key in s_file]
+        matching_files = [join(self._path, file_name) for file_name in all_files if key in file_name]
         return matching_files
 
     def run(self):

--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -27,16 +27,16 @@ class SrBagRotate:
         self.run()
 
     def remove_old_bags(self):
-        bags_to_remove = self.get_file_names(".bag")
+        bags_to_remove = self.get_file_paths_by_key(".bag")
         bags_to_remove.sort()
 
         for i, bag in enumerate(bags_to_remove):
             if i < len(bags_to_remove)-self._desired_bag_number - 1:
                 remove(bag)
 
-    def get_file_names(self, key):
+    def get_file_paths_by_key(self, key):
         all_files = listdir(self._path)
-        matching_files = [s_file for s_file in all_files if s_file.find(key)]
+        matching_files = [f"{self._path}/{s_file}" for s_file in all_files if key in s_file]
         return matching_files
 
     def run(self):

--- a/sr_logging_common/logging/bag_rotate.py
+++ b/sr_logging_common/logging/bag_rotate.py
@@ -36,11 +36,7 @@ class SrBagRotate:
 
     def get_file_names(self, key):
         all_files = listdir(self._path)
-        all_bags = [s_file for s_file in all_files if s_file.find(key)]
-        matching_files = []
-        for bag in all_bags:
-            if key in bag:
-                matching_files.append(f"{self._path}/{bag}")
+        matching_files = [s_file for s_file in all_files if s_file.find(key)]
         return matching_files
 
     def run(self):


### PR DESCRIPTION
## Proposed changes

Following this error https://shadowrobot.atlassian.net/browse/SRC-7285, this PR removes reindexing active rosbags from the rosbag rotate script and also adds any file that contains .bag in the name to the file window of rosbag rotate.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
