### PR TITLE
Use intended implementation of launch prefix

### DIFF
--- a/sr_utilities_common/src/sr_utilities_common/conditional_delayed_rostool.py
+++ b/sr_utilities_common/src/sr_utilities_common/conditional_delayed_rostool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2020, 2022 Shadow Robot Company Ltd.
+# Copyright 2020, 2022, 2025 Shadow Robot Company Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the Free

--- a/sr_utilities_common/src/sr_utilities_common/conditional_delayed_rostool.py
+++ b/sr_utilities_common/src/sr_utilities_common/conditional_delayed_rostool.py
@@ -101,6 +101,7 @@ if __name__ == "__main__":
     executable_name = rospy.get_param("~executable_name")
     arguments_list = rospy.get_param("~launch_args_list", "")
     node_launch_prefix = rospy.get_param("~launch_prefix", "")
+    node_launch_prefix_arg_str = f"--prefix {node_launch_prefix}" if node_launch_prefix else ""
     timeout_param = rospy.get_param("~timeout", 0)
 
     if rospy.has_param('~topics_list'):
@@ -129,7 +130,7 @@ if __name__ == "__main__":
         if executable_name.endswith('.launch'):
             os.system("roslaunch {} {} {}".format(package_name, executable_name, arguments_list))
         else:
-            os.system("{} rosrun {} {} {}".format(node_launch_prefix, package_name, executable_name, arguments_list))
+            os.system(f"rosrun {node_launch_prefix_arg_str} {package_name} {executable_name} {arguments_list}")
     else:
         rospy.logfatal("{}: Could not launch {} {}, make sure all required conditions are met".format(rospy.get_name(),
                                                                                                       package_name,


### PR DESCRIPTION
## Proposed changes

Use the `--prefix` arg in rosrun instead of appended launch args in front of rosrun. This allows the rosrun command to fully resolve to the full executable path before applying the launch prefix (allowing path depended prefixes like `ethercat_grant` to works properly)

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
